### PR TITLE
Change skimage.draw.circle to skimage.draw.ellipse

### DIFF
--- a/code/fringe_tracing_fourier.py
+++ b/code/fringe_tracing_fourier.py
@@ -2,7 +2,7 @@ import os
 from skimage.color import rgb2gray
 from skimage.io import imread, imsave
 from skimage.morphology import thin, skeletonize
-from skimage.draw import circle
+from skimage.draw import ellipse
 from skimage.filters import gaussian
 #from scipy.misc import imsave
 
@@ -24,9 +24,9 @@ def create_filter(fft, R0, theta, radius_of_filter, blur):
     fft_filter=np.zeros_like(np.abs(fft))
 
     # two circle filter
-    rr, cc = circle(r=y1, c=x1, radius=radius_of_filter, shape=fft_filter.shape)
+    rr, cc = ellipse(r=y1, c=x1, r_radius=radius_of_filter, c_radius=radius_of_filter, shape=fft_filter.shape)
     fft_filter[rr, cc] = 1
-    rr, cc = circle(r=y2, c=x2, radius=radius_of_filter, shape=fft_filter.shape)
+    rr, cc = circle(r=y2, c=x2, r_radius=radius_of_filter, c_radius=radius_of_filter, shape=fft_filter.shape)
     fft_filter[rr, cc] = 1
     
     fft_filter=gaussian(fft_filter, blur)


### PR DESCRIPTION
Update references to the circle function in skimage.draw, to use ellipse instead (so we maintain support the latest stable version of scikit-image, 0.19.0, whilst also maintaining backwards compatibility).

The updated implementation with ellipse simply uses the same radius for both the major and minor radii: retaining the result produced by the circle function, but using the ellipse function (since the circle function is no longer implemented in scikit-image 0.19.0)